### PR TITLE
Civic: Update shouldWriteCookies callback to async, so the Civic auth server can look up the state parameter from the db for the end_session endpoint

### DIFF
--- a/CIVIC_CHANGES.md
+++ b/CIVIC_CHANGES.md
@@ -15,7 +15,7 @@ With only this flag set, the cookies will still be set by the auth server, and c
    new Provider(issuer, {
      cookies: {
        enableCookielessFallback: true,
-       shouldWriteCookies(ctx) {
+       async shouldWriteCookies(ctx) {
          // Custom logic to determine if cookies should be written
          // Example: Don't write cookies for requests with Civic SDK state parameters
          const stateParam = ctx.query?.state || ctx.oidc?.params?.state;

--- a/lib/actions/authorization/interactions.js
+++ b/lib/actions/authorization/interactions.js
@@ -129,7 +129,7 @@ export default async function interactions(resumeRouteName, ctx, next) {
 
   const destination = await interactionUrl(ctx, interactionSession);
   
-  if (shouldWriteCookies(ctx)) {
+  if (await shouldWriteCookies(ctx)) {
     ctx.cookies.set(oidc.provider.cookieName("interaction"), uid, {
       path: new URL(destination, ctx.oidc.issuer).pathname,
       ...cookieOptions,

--- a/lib/actions/authorization/resume.js
+++ b/lib/actions/authorization/resume.js
@@ -95,7 +95,7 @@ export default async function resumeAction(allowList, resumeRouteName, ctx, next
   ctx.oidc.trusted = trusted;
   ctx.oidc.redirectUriCheckPerformed = true;
 
-  if (shouldWriteCookies(ctx)) {
+  if (await shouldWriteCookies(ctx)) {
     const cookieOptions = instance(ctx.oidc.provider).configuration.cookies.short;
     const clearOpts = {
       ...cookieOptions,

--- a/lib/helpers/cookie_helpers.js
+++ b/lib/helpers/cookie_helpers.js
@@ -1,11 +1,11 @@
 import instance from "./weak_cache.js";
 
-export function shouldWriteCookies(ctx) {
+export async function shouldWriteCookies(ctx) {
     const cookieConfig = instance(ctx.oidc.provider).configuration.cookies;
     
     // If a custom shouldWriteCookies function is provided, use it
     if (typeof cookieConfig.shouldWriteCookies === 'function') {
-        return cookieConfig.shouldWriteCookies(ctx);
+        return await cookieConfig.shouldWriteCookies(ctx);
     }
     
     // Fallback to doNotSet flag from config.

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -910,7 +910,7 @@ function makeDefaults() {
        * example: Conditionally disable cookies based on request parameters
        *
        * ```js
-       * shouldWriteCookies(ctx) {
+       * async shouldWriteCookies(ctx) {
        *   // Don't write cookies for specific client types or request patterns
        *   const stateParam = ctx.query?.state || ctx.oidc?.params?.state;
        *   return !isSpecialClient(stateParam);

--- a/lib/shared/session.js
+++ b/lib/shared/session.js
@@ -32,7 +32,7 @@ export default async function sessionHandler(ctx, next) {
   try {
     await next();
   } finally {
-    const writeCookies = shouldWriteCookies(ctx);
+    const writeCookies = await shouldWriteCookies(ctx);
     const sessionCookieName = ctx.oidc.provider.cookieName("session");
     const longRegExp = new RegExp(`^${sessionCookieName}(?:\\.sig)?=`);
 

--- a/test/actions/authorization/interactions_cookie_logic.test.js
+++ b/test/actions/authorization/interactions_cookie_logic.test.js
@@ -44,10 +44,10 @@ describe('interactions cookie logic integration', () => {
   });
 
   describe('interaction middleware cookie behavior', () => {
-    it('should clear cookies when shouldWriteCookies returns false', () => {
+    it('should clear cookies when shouldWriteCookies returns false', async () => {
       mockInstance.configuration.cookies.doNotSet = true;
       
-      const shouldWrite = shouldWriteCookies(mockCtx);
+      const shouldWrite = await shouldWriteCookies(mockCtx);
       expect(shouldWrite).to.be.false;
       
       // Simulate the interaction middleware behavior
@@ -66,10 +66,10 @@ describe('interactions cookie logic integration', () => {
       expect(mockCtx.cookies.set.calledWith('_session', null)).to.be.true;
     });
 
-    it('should set interaction cookie when shouldWriteCookies returns true', () => {
+    it('should set interaction cookie when shouldWriteCookies returns true', async () => {
       mockInstance.configuration.cookies.doNotSet = false;
       
-      const shouldWrite = shouldWriteCookies(mockCtx);
+      const shouldWrite = await shouldWriteCookies(mockCtx);
       expect(shouldWrite).to.be.true;
       
       // Simulate the interaction middleware behavior
@@ -89,11 +89,11 @@ describe('interactions cookie logic integration', () => {
       })).to.be.true;
     });
 
-    it('should handle custom shouldWriteCookies function in interaction flow', () => {
+    it('should handle custom shouldWriteCookies function in interaction flow', async () => {
       const customFunction = sinon.stub().returns(true);
       mockInstance.configuration.cookies.shouldWriteCookies = customFunction;
       
-      const shouldWrite = shouldWriteCookies(mockCtx);
+      const shouldWrite = await shouldWriteCookies(mockCtx);
       expect(shouldWrite).to.be.true;
       expect(customFunction.calledWith(mockCtx)).to.be.true;
       

--- a/test/shared/session_cookie_logic.test.js
+++ b/test/shared/session_cookie_logic.test.js
@@ -63,10 +63,10 @@ describe('session cookie logic integration', () => {
   });
 
   describe('shouldWriteCookies integration with clearAllCookies', () => {
-    it('should clear cookies when shouldWriteCookies returns false', () => {
+    it('should clear cookies when shouldWriteCookies returns false', async () => {
       mockInstance.configuration.cookies.doNotSet = true;
       
-      const shouldWrite = shouldWriteCookies(mockCtx);
+      const shouldWrite = await shouldWriteCookies(mockCtx);
       expect(shouldWrite).to.be.false;
       
       if (!shouldWrite) {
@@ -76,10 +76,10 @@ describe('session cookie logic integration', () => {
       expect(mockCtx.cookies.set.calledThrice).to.be.true;
     });
 
-    it('should not clear cookies when shouldWriteCookies returns true', () => {
+    it('should not clear cookies when shouldWriteCookies returns true', async () => {
       mockInstance.configuration.cookies.doNotSet = false;
       
-      const shouldWrite = shouldWriteCookies(mockCtx);
+      const shouldWrite = await shouldWriteCookies(mockCtx);
       expect(shouldWrite).to.be.true;
       
       if (!shouldWrite) {
@@ -89,11 +89,11 @@ describe('session cookie logic integration', () => {
       expect(mockCtx.cookies.set.called).to.be.false;
     });
 
-    it('should use custom shouldWriteCookies function and clear appropriately', () => {
+    it('should use custom shouldWriteCookies function and clear appropriately', async () => {
       const customFunction = sinon.stub().returns(false);
       mockInstance.configuration.cookies.shouldWriteCookies = customFunction;
       
-      const shouldWrite = shouldWriteCookies(mockCtx);
+      const shouldWrite = await shouldWriteCookies(mockCtx);
       expect(shouldWrite).to.be.false;
       expect(customFunction.calledWith(mockCtx)).to.be.true;
       


### PR DESCRIPTION
Civic: Update shouldWriteCookies callback to async, so the Civic auth server can look up the state parameter from the db for the end_session endpoint