### PR TITLE
Refresh token grace period

### DIFF
--- a/CIVIC_CHANGES.md
+++ b/CIVIC_CHANGES.md
@@ -29,12 +29,15 @@ With only this flag set, the cookies will still be set by the auth server, and c
 
    If `shouldWriteCookies` returns false, any existing cookies from previous sessions are also deleted, in addition to not writing cookies for the current session.
 
-4. Refresh Token Grace Period (`refreshTokenGracePeriodSeconds`)
-   The library now supports a configurable grace period for refresh tokens to address multi-tab/session scenarios where clients may have cached tokens that become invalid due to rotation or revocation by other sessions.
+4. Refresh Token Tolerance Configuration (`refreshTolerance`)
+   The library now supports configurable refresh token tolerance settings to address multi-tab/session scenarios where clients may have cached tokens that become invalid due to rotation or revocation by other sessions.
 
    ```js
    new Provider(issuer, {
-     refreshTokenGracePeriodSeconds: 10, // Allow consumed tokens to be valid for 10 more seconds
+     refreshTolerance: {
+       gracePeriodSeconds: 10, // Allow consumed tokens to be valid for 10 more seconds
+       revokeEntireGrantAfterGracePeriod: true, // Revoke entire grant if token used beyond grace period
+     },
    })
    ```
 
@@ -57,18 +60,23 @@ With only this flag set, the cookies will still be set by the auth server, and c
    ```js
    // Conservative production setting
    new Provider(issuer, {
-     refreshTokenGracePeriodSeconds: 15, // 15 second grace period
+     refreshTolerance: {
+       gracePeriodSeconds: 15, // 15 second grace period
+       revokeEntireGrantAfterGracePeriod: true, // Default security behavior
+     },
      rotateRefreshToken: true, // Enable token rotation
    })
    ```
 
-5. Refresh Token Grace Period Grant Revocation Control (`refreshTokenGracePeriodRevokeEntireGrant`)
+5. Refresh Token Grace Period Grant Revocation Control (`refreshTolerance.revokeEntireGrantAfterGracePeriod`)
    This configuration flag controls the behavior when a refresh token is presented beyond its grace period, providing granular control over security responses to out-of-grace token usage.
 
    ```js
    new Provider(issuer, {
-     refreshTokenGracePeriodSeconds: 10, // Enable grace period
-     refreshTokenGracePeriodRevokeEntireGrant: false, // Only invalidate specific token
+     refreshTolerance: {
+       gracePeriodSeconds: 10, // Enable grace period
+       revokeEntireGrantAfterGracePeriod: false, // Only invalidate specific token
+     },
    })
    ```
 
@@ -90,8 +98,10 @@ With only this flag set, the cookies will still be set by the auth server, and c
    ```js
    // Granular token invalidation mode
    new Provider(issuer, {
-     refreshTokenGracePeriodSeconds: 10, // 10 second grace period
-     refreshTokenGracePeriodRevokeEntireGrant: false, // Only invalidate specific token
+     refreshTolerance: {
+       gracePeriodSeconds: 10, // 10 second grace period
+       revokeEntireGrantAfterGracePeriod: false, // Only invalidate specific token
+     },
      rotateRefreshToken: true,
    })
    ```
@@ -109,7 +119,10 @@ With only this flag set, the cookies will still be set by the auth server, and c
    **Usage Example:**
    ```js
    const provider = new Provider(issuer, {
-     refreshTokenGracePeriodSeconds: 10, // Enable grace period
+     refreshTolerance: {
+       gracePeriodSeconds: 10, // Enable grace period
+       revokeEntireGrantAfterGracePeriod: true, // Default behavior
+     },
    });
 
    // Listen for grace period reuse events
@@ -132,6 +145,6 @@ With only this flag set, the cookies will still be set by the auth server, and c
    - **Audit Logging**: Maintain detailed logs of all grace period token reuse for compliance
 
    **Event Properties:**
-   - Only emitted when `refreshTokenGracePeriodSeconds` is configured and greater than 0
+   - Only emitted when `refreshTolerance.gracePeriodSeconds` is configured and greater than 0
    - Not emitted for tokens that are reused beyond their grace period (those trigger errors instead)
    - Provides full context about the request and token for comprehensive logging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+This is a fork of panva's node-oidc-provider (upstream [here](https://github.com/panva/node-oidc-provider), Civic's fork [here](https://github.com/civicteam/node-oidc-provider)).
+
+This fork is used as the basis of the Auth Server in Civic's Auth product. The Civic-specific changes (reasons for forking) can be found in CIVIC_CHANGES.md.
+
+When maintaining and making changes to this fork, our goals are as follows:
+1. Regularly sync from upstream to get the latest security updates and new features, so that our fork does not fall behind
+2. Any change must clearly be documented in CIVIC_CHANGES.md, most importantly describing *why* the change was needed, and what the trade-offs are (e.g. cookieless support for iframes trades off against 100% session authenticity verification).
+3. We have to clearly understand how our changes impact adherance to the relevant OAuth and OIDC specs, and where we deviate, we must be sure it's documented and justified.
+4. Ensure that there are tests for all changes.

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -138,9 +138,9 @@ export const handler = async function refreshTokenHandler(ctx) {
     // Check if grace period allows this consumed token to still be valid
     if (!refreshToken.isValid) {
       // Token is beyond grace period
-      const { refreshTokenGracePeriodRevokeEntireGrant } = instance(ctx.oidc.provider).configuration;
+      const { refreshTolerance: { revokeEntireGrantAfterGracePeriod } } = instance(ctx.oidc.provider).configuration;
       
-      if (refreshTokenGracePeriodRevokeEntireGrant) {
+      if (revokeEntireGrantAfterGracePeriod) {
         // Revoke entire grant for security (default behavior)
         await Promise.all([
           refreshToken.destroy(),

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -2859,66 +2859,69 @@ function makeDefaults() {
     rotateRefreshToken,
 
     /*
-     * refreshTokenGracePeriodSeconds
+     * refreshTolerance
      *
-     * description: Specifies the grace period in seconds during which consumed or revoked 
-     *   refresh tokens remain valid for authentication. This feature addresses multi-tab/session 
-     *   scenarios where clients may have cached tokens that become invalid due to rotation or 
-     *   revocation by other sessions.
+     * description: Configuration object for refresh token tolerance settings that control
+     *   grace period behavior and grant revocation policies for refresh tokens.
      * 
-     * When set to a positive value:
-     * - Consumed refresh tokens remain valid for the specified grace period duration
-     * - Revoked refresh tokens can still be used within the grace period
-     * - During token rotation, both old and new tokens remain valid during the grace period
-     * - Grace period applies regardless of revocation reason (explicit revocation, TTL expiry, etc.)
-     * 
-     * Security considerations:
-     * - Extends the attack window for compromised refresh tokens
-     * - Allows multiple valid tokens for the same grant during grace period
-     * - Should be set to minimum duration necessary (recommended: 5-15 seconds for production)
-     * - Default value of undefined maintains strict OAuth security behavior
-     * 
-     * recommendation: Use conservative values (5-30 seconds) and only when multi-session 
-     *   token conflicts are observed in production environments.
-     * 
-     * example: Enable 10-second grace period for refresh tokens
+     * example: Configure refresh token tolerance settings
      * 
      * ```js
      * {
-     *   refreshTokenGracePeriodSeconds: 10
+     *   refreshTolerance: {
+     *     gracePeriodSeconds: 10,
+     *     revokeEntireGrantAfterGracePeriod: false
+     *   }
      * }
      * ```
      */
-    refreshTokenGracePeriodSeconds: undefined,
+    refreshTolerance: {
+      /*
+       * gracePeriodSeconds
+       *
+       * description: Specifies the grace period in seconds during which consumed or revoked 
+       *   refresh tokens remain valid for authentication. This feature addresses multi-tab/session 
+       *   scenarios where clients may have cached tokens that become invalid due to rotation or 
+       *   revocation by other sessions.
+       * 
+       * When set to a positive value:
+       * - Consumed refresh tokens remain valid for the specified grace period duration
+       * - Revoked refresh tokens can still be used within the grace period
+       * - During token rotation, both old and new tokens remain valid during the grace period
+       * - Grace period applies regardless of revocation reason (explicit revocation, TTL expiry, etc.)
+       * 
+       * Security considerations:
+       * - Extends the attack window for compromised refresh tokens
+       * - Allows multiple valid tokens for the same grant during grace period
+       * - Should be set to minimum duration necessary (recommended: 5-15 seconds for production)
+       * - Default value of undefined maintains strict OAuth security behavior
+       * 
+       * recommendation: Use conservative values (5-30 seconds) and only when multi-session 
+       *   token conflicts are observed in production environments.
+       */
+      gracePeriodSeconds: undefined,
 
-    /*
-     * refreshTokenGracePeriodRevokeEntireGrant
-     *
-     * description: Controls the behavior when a refresh token is presented beyond its grace period.
-     *   When true (default), presenting an out-of-grace refresh token revokes the entire grant 
-     *   and all associated tokens for security. When false, only the specific token is invalidated
-     *   while other tokens in the grant remain valid.
-     * 
-     * Security considerations:
-     * - Setting to false reduces security as potentially compromised tokens don't trigger 
-     *   full grant revocation
-     * - Setting to true (default) provides maximum security by assuming token compromise
-     *   when presented beyond grace period
-     * - Should generally remain true unless specific use cases require token-level invalidation
-     * 
-     * recommendation: Keep default value of true for maximum security. Only set to false
-     *   when token-level granular control is specifically required and security implications
-     *   are well understood.
-     * 
-     * example: Disable entire grant revocation for out-of-grace tokens
-     * 
-     * ```js
-     * {
-     *   refreshTokenGracePeriodRevokeEntireGrant: false
-     * }
-     * ```
-     */
-    refreshTokenGracePeriodRevokeEntireGrant: true,
+      /*
+       * revokeEntireGrantAfterGracePeriod
+       *
+       * description: Controls the behavior when a refresh token is presented beyond its grace period.
+       *   When true (default), presenting an out-of-grace refresh token revokes the entire grant 
+       *   and all associated tokens for security. When false, only the specific token is invalidated
+       *   while other tokens in the grant remain valid.
+       * 
+       * Security considerations:
+       * - Setting to false reduces security as potentially compromised tokens don't trigger 
+       *   full grant revocation
+       * - Setting to true (default) provides maximum security by assuming token compromise
+       *   when presented beyond grace period
+       * - Should generally remain true unless specific use cases require token-level invalidation
+       * 
+       * recommendation: Keep default value of true for maximum security. Only set to false
+       *   when token-level granular control is specifically required and security implications
+       *   are well understood.
+       */
+      revokeEntireGrantAfterGracePeriod: true,
+    },
 
     /*
      * enabledJWA

--- a/lib/models/refresh_token.js
+++ b/lib/models/refresh_token.js
@@ -51,7 +51,7 @@ export default (provider) => class RefreshToken extends apply([
    */
   get isValid() {
     const configuration = instance(provider).configuration;
-    const gracePeriodSeconds = configuration.refreshTokenGracePeriodSeconds;
+    const gracePeriodSeconds = configuration.refreshTolerance.gracePeriodSeconds;
     
     // Original validation: not consumed and not expired
     if (!this.consumed && !this.isExpired) {

--- a/test/refresh/refresh.grant.test.js
+++ b/test/refresh/refresh.grant.test.js
@@ -637,14 +637,20 @@ describe('grant_type=refresh_token', () => {
     });
   });
 
-  describe('refreshTokenGracePeriodSeconds configuration', () => {
+  describe('refreshTolerance.gracePeriodSeconds configuration', () => {
     beforeEach(function () {
-      i(this.provider).configuration.refreshTokenGracePeriodSeconds = 10; // 10 seconds grace period
+      i(this.provider).configuration.refreshTolerance = {
+        gracePeriodSeconds: 10, // 10 seconds grace period
+        revokeEntireGrantAfterGracePeriod: true
+      };
       i(this.provider).configuration.rotateRefreshToken = true;
     });
 
     afterEach(function () {
-      i(this.provider).configuration.refreshTokenGracePeriodSeconds = undefined;
+      i(this.provider).configuration.refreshTolerance = {
+        gracePeriodSeconds: undefined,
+        revokeEntireGrantAfterGracePeriod: true
+      };
       i(this.provider).configuration.rotateRefreshToken = false;
     });
 
@@ -762,7 +768,7 @@ describe('grant_type=refresh_token', () => {
     });
 
     it('maintains strict validation when grace period is disabled', function (done) {
-      i(this.provider).configuration.refreshTokenGracePeriodSeconds = 0; // Disable grace period
+      i(this.provider).configuration.refreshTolerance.gracePeriodSeconds = 0; // Disable grace period
       const gracePeriodEventSpy = sinon.spy();
       this.provider.on('refresh_token.reused_within_grace_period', gracePeriodEventSpy);
 
@@ -874,20 +880,25 @@ describe('grant_type=refresh_token', () => {
         });
     });
 
-    describe('refreshTokenGracePeriodRevokeEntireGrant configuration', () => {
+    describe('refreshTolerance.revokeEntireGrantAfterGracePeriod configuration', () => {
       beforeEach(function () {
-        i(this.provider).configuration.refreshTokenGracePeriodSeconds = 10; // 10 seconds grace period
+        i(this.provider).configuration.refreshTolerance = {
+          gracePeriodSeconds: 10, // 10 seconds grace period
+          revokeEntireGrantAfterGracePeriod: true
+        };
         i(this.provider).configuration.rotateRefreshToken = true;
       });
 
       afterEach(function () {
-        i(this.provider).configuration.refreshTokenGracePeriodSeconds = undefined;
+        i(this.provider).configuration.refreshTolerance = {
+          gracePeriodSeconds: undefined,
+          revokeEntireGrantAfterGracePeriod: true
+        };
         i(this.provider).configuration.rotateRefreshToken = false;
-        i(this.provider).configuration.refreshTokenGracePeriodRevokeEntireGrant = true; // Reset to default
       });
 
       it('revokes entire grant when flag is true (default behavior)', function (done) {
-        i(this.provider).configuration.refreshTokenGracePeriodRevokeEntireGrant = true;
+        i(this.provider).configuration.refreshTolerance.revokeEntireGrantAfterGracePeriod = true;
         let newRefreshToken;
         const grantRevokeSpy = sinon.spy();
         this.provider.on('grant.revoked', grantRevokeSpy);
@@ -946,7 +957,7 @@ describe('grant_type=refresh_token', () => {
       });
 
       it('only invalidates specific token when flag is false', function (done) {
-        i(this.provider).configuration.refreshTokenGracePeriodRevokeEntireGrant = false;
+        i(this.provider).configuration.refreshTolerance.revokeEntireGrantAfterGracePeriod = false;
         let newRefreshToken;
         const grantRevokeSpy = sinon.spy();
         this.provider.on('grant.revoked', grantRevokeSpy);
@@ -1005,7 +1016,7 @@ describe('grant_type=refresh_token', () => {
       });
 
       it('maintains grace period behavior regardless of revocation flag setting', function (done) {
-        i(this.provider).configuration.refreshTokenGracePeriodRevokeEntireGrant = false;
+        i(this.provider).configuration.refreshTolerance.revokeEntireGrantAfterGracePeriod = false;
         const gracePeriodEventSpy = sinon.spy();
         this.provider.on('refresh_token.reused_within_grace_period', gracePeriodEventSpy);
 


### PR DESCRIPTION
Implement an optional tolerance (grace period) for refresh tokens, so that a token can be re-used for a configurable length of time after being consumed (rotated) or expiring.

Corresponding Civic Auth PR that uses this version of the fork: https://github.com/civicteam/civic-auth/pull/2148