### PR TITLE
Support dynamic claims

### DIFF
--- a/lib/helpers/claims.js
+++ b/lib/helpers/claims.js
@@ -5,7 +5,7 @@ import isPlainObject from './_/is_plain_object.js';
 
 export default function getClaims(provider) {
   const {
-    claims: claimConfig, claimsSupported, pairwiseIdentifier,
+    claims: claimConfig, claimsSupported, pairwiseIdentifier, allowDynamicClaims,
   } = instance(provider).configuration;
 
   return class Claims {
@@ -52,7 +52,7 @@ export default function getClaims(provider) {
 
           return undefined;
         })
-        .filter((key) => key && claimsSupported.has(key));
+        .filter((key) => key && (allowDynamicClaims || claimsSupported.has(key)));
 
       const claims = pick(available, ...include);
 

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -799,6 +799,19 @@ function makeDefaults() {
      *
      */
     conformIdTokenClaims: true,
+    /*
+     * allowDynamicClaims
+     *
+     * description: When enabled, bypasses the static claims filtering that normally restricts
+     *   returned claims to those listed in the `claimsSupported` configuration. This allows
+     *   the `findAccount.claims()` method to return arbitrary claims from external sources
+     *   without being filtered against the static claims configuration. Default: false.
+     *
+     * Trade-offs: Enables fully dynamic claim mappings from external sources but reduces
+     *   the static validation safety net for claims. External claim sources must be
+     *   properly secured and validated.
+     */
+    allowDynamicClaims: false,
 
     /*
      * loadExistingGrant

--- a/lib/helpers/oidc_context.js
+++ b/lib/helpers/oidc_context.js
@@ -116,10 +116,10 @@ export default function getContext(provider) {
           userinfo, id_token: idToken,
         } = JSON.parse(this.params.claims);
 
-        const claims = instance(provider).configuration.claimsSupported;
+        const { claimsSupported, allowDynamicClaims } = instance(provider).configuration;
         if (userinfo) {
           Object.entries(userinfo).forEach(([claim, value]) => {
-            if (claims.has(claim) && (value === null || isPlainObject(value))) {
+            if ((allowDynamicClaims || claimsSupported.has(claim)) && (value === null || isPlainObject(value))) {
               requestParamClaims.add(claim);
             }
           });
@@ -127,7 +127,7 @@ export default function getContext(provider) {
 
         if (idToken) {
           Object.entries(idToken).forEach(([claim, value]) => {
-            if (claims.has(claim) && (value === null || isPlainObject(value))) {
+            if ((allowDynamicClaims || claimsSupported.has(claim)) && (value === null || isPlainObject(value))) {
               requestParamClaims.add(claim);
             }
           });

--- a/test/claims/allow_dynamic_claims.config.js
+++ b/test/claims/allow_dynamic_claims.config.js
@@ -1,0 +1,32 @@
+import merge from 'lodash/merge.js';
+
+import getConfig from '../default.config.js';
+
+const config = getConfig();
+
+// Enable claims parameter feature for testing
+merge(config.features, { claimsParameter: { enabled: true } });
+
+// Add some scopes for testing
+config.scopes = new Set(['openid', 'email', 'profile', 'custom']);
+
+// Define static claims that are always supported
+config.claims = {
+  openid: ['sub'],
+  email: ['email'],
+  profile: ['name', 'given_name', 'family_name'],
+  custom: [], // Empty but scope exists
+};
+
+export default {
+  config,
+  clients: [
+    {
+      client_id: 'client',
+      client_secret: 'secret',
+      grant_types: ['implicit', 'authorization_code'],
+      response_types: ['id_token token', 'id_token', 'code', 'none'],
+      redirect_uris: ['https://client.example.com/cb'],
+    },
+  ],
+};

--- a/test/claims/allow_dynamic_claims.test.js
+++ b/test/claims/allow_dynamic_claims.test.js
@@ -1,0 +1,390 @@
+/* eslint-disable no-underscore-dangle */
+
+import { parse as parseLocation } from 'node:url';
+
+import { expect } from 'chai';
+
+import { decode as decodeJWT } from '../../lib/helpers/jwt.js';
+import bootstrap from '../test_helper.js';
+
+const route = '/auth';
+
+['get', 'post'].forEach((verb) => {
+  describe(`allowDynamicClaims feature via ${verb} ${route}`, () => {
+    before(bootstrap(import.meta.url));
+
+    describe('configuration validation', () => {
+      it('should default to false', function () {
+        expect(this.provider.issuer).to.be.ok;
+        const config = this.provider.Client.Schema.get('allowDynamicClaims');
+        expect(config).to.be.undefined; // It's not a client property, it's a provider config
+        
+        // Access the provider configuration through the internal instance
+        const providerConfig = this.provider.constructor.prototype.configuration || this.provider.configuration;
+        // Check the actual provider instance configuration
+        expect(this.provider.allowDynamicClaims).to.be.undefined; // Not directly accessible
+      });
+    });
+
+    describe('when allowDynamicClaims is false (default)', () => {
+      before(function () {
+        return this.login({
+          claims: {
+            id_token: {
+              email: null,
+              dynamic_claim: null, // This shouldn't work with default config
+            },
+          },
+        });
+      });
+      after(function () { return this.logout(); });
+
+      it('should filter out non-static claims from id_token', function () {
+        const auth = new this.AuthorizationRequest({
+          response_type: 'id_token token',
+          scope: 'openid email',
+          claims: {
+            id_token: {
+              email: null,
+              dynamic_claim: null, // Not in claimsSupported, should be filtered
+              custom_external_claim: null, // Not in claimsSupported, should be filtered
+            },
+          },
+        });
+
+        return this.wrap({ route, verb, auth })
+          .expect(303)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['id_token'], false))
+          .expect((response) => {
+            const { query: { id_token } } = parseLocation(response.headers.location, true);
+            const { payload } = decodeJWT(id_token);
+            expect(payload).to.have.key('email'); // Static claim should be present
+            expect(payload).not.to.have.keys('dynamic_claim', 'custom_external_claim'); // Dynamic claims should be filtered
+          });
+      });
+
+      it('should filter out non-static claims from userinfo', function (done) {
+        const auth = new this.AuthorizationRequest({
+          response_type: 'id_token token',
+          scope: 'openid email',
+          claims: {
+            userinfo: {
+              email: null,
+              dynamic_claim: null, // Not in claimsSupported, should be filtered
+              external_api_claim: null, // Not in claimsSupported, should be filtered
+            },
+          },
+        });
+
+        this.wrap({ route, verb, auth })
+          .expect(303)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['access_token'], false))
+          .end((err, response) => {
+            if (err) {
+              return done(err);
+            }
+
+            const { query: { access_token } } = parseLocation(response.headers.location, true);
+            return this.agent
+              .get('/me')
+              .auth(access_token, { type: 'bearer' })
+              .expect(200)
+              .expect(({ body }) => {
+                expect(body).to.have.key('email'); // Static claim should be present
+                expect(body).not.to.have.keys('dynamic_claim', 'external_api_claim'); // Dynamic claims should be filtered
+              })
+              .end(done);
+          });
+      });
+    });
+
+    describe('claims parameter validation with default behavior', () => {
+      it('should reject claims parameter with non-static claims', function () {
+        const auth = new this.AuthorizationRequest({
+          response_type: 'id_token token',
+          scope: 'openid',
+          claims: {
+            id_token: {
+              non_existent_claim: null, // Not in claimsSupported, should cause issues
+            },
+          },
+        });
+
+        return this.wrap({ route, verb, auth })
+          .expect(303)
+          .expect(auth.validateFragment)
+          .expect((response) => {
+            const { query: { id_token } } = parseLocation(response.headers.location, true);
+            const { payload } = decodeJWT(id_token);
+            expect(payload).not.to.have.key('non_existent_claim'); // Should be filtered
+          });
+      });
+    });
+  });
+});
+
+// Test with allowDynamicClaims enabled - need separate config file
+describe('allowDynamicClaims feature when enabled', () => {
+  before(bootstrap(import.meta.url.replace('.test.js', '_enabled.config.js')));
+
+  ['get', 'post'].forEach((verb) => {
+    describe(`via ${verb} ${route} with allowDynamicClaims enabled`, () => {
+      before(function () {
+        return this.login({
+          claims: {
+            id_token: {
+              email: null,
+              dynamic_claim: null,
+              external_api_claim: null,
+            },
+          },
+        });
+      });
+      after(function () { return this.logout(); });
+
+      it('should include dynamic claims in id_token', function () {
+        const auth = new this.AuthorizationRequest({
+          response_type: 'id_token token',
+          scope: 'openid email',
+          claims: {
+            id_token: {
+              email: null,
+              dynamic_claim: null,
+              external_api_claim: null,
+              tenant_specific_claim: null,
+            },
+          },
+        });
+
+        return this.wrap({ route, verb, auth })
+          .expect(303)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['id_token'], false))
+          .expect((response) => {
+            const { query: { id_token } } = parseLocation(response.headers.location, true);
+            const { payload } = decodeJWT(id_token);
+            expect(payload).to.have.keys('email', 'dynamic_claim', 'external_api_claim', 'tenant_specific_claim');
+            expect(payload.dynamic_claim).to.equal('dynamic_value');
+            expect(payload.external_api_claim).to.equal('from_external_api');
+            expect(payload.tenant_specific_claim).to.equal('tenant_123');
+          });
+      });
+
+      it('should include dynamic claims in userinfo', function (done) {
+        const auth = new this.AuthorizationRequest({
+          response_type: 'id_token token',
+          scope: 'openid email',
+          claims: {
+            userinfo: {
+              email: null,
+              dynamic_claim: null,
+              external_api_claim: null,
+              tenant_specific_claim: null,
+            },
+          },
+        });
+
+        this.wrap({ route, verb, auth })
+          .expect(303)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['access_token'], false))
+          .end((err, response) => {
+            if (err) {
+              return done(err);
+            }
+
+            const { query: { access_token } } = parseLocation(response.headers.location, true);
+            return this.agent
+              .get('/me')
+              .auth(access_token, { type: 'bearer' })
+              .expect(200)
+              .expect(({ body }) => {
+                expect(body).to.have.keys('sub', 'email', 'dynamic_claim', 'external_api_claim', 'tenant_specific_claim');
+                expect(body.dynamic_claim).to.equal('dynamic_value');
+                expect(body.external_api_claim).to.equal('from_external_api');
+                expect(body.tenant_specific_claim).to.equal('tenant_123');
+              })
+              .end(done);
+          });
+      });
+
+      it('should accept claims parameter with dynamic claims', function () {
+        const auth = new this.AuthorizationRequest({
+          response_type: 'id_token token',
+          scope: 'openid',
+          claims: {
+            id_token: {
+              completely_new_claim: null, // Not in claimsSupported, but should work with allowDynamicClaims
+              another_dynamic_claim: {
+                essential: true,
+              },
+            },
+          },
+        });
+
+        return this.wrap({ route, verb, auth })
+          .expect(303)
+          .expect(auth.validateFragment)
+          .expect((response) => {
+            // Should not error and should process the request
+            expect(response.headers.location).to.match(/#/);
+          });
+      });
+
+      it('should still respect grant-level permissions', function () {
+        // Even with allowDynamicClaims, grant-level security should still work
+        const auth = new this.AuthorizationRequest({
+          response_type: 'id_token',
+          scope: 'openid', // No email scope
+          claims: {
+            id_token: {
+              email: null, // Requesting email without email scope
+              dynamic_claim: null,
+            },
+          },
+        });
+
+        return this.wrap({ route, verb, auth })
+          .expect(303)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['id_token'], false))
+          .expect((response) => {
+            const { query: { id_token } } = parseLocation(response.headers.location, true);
+            const { payload } = decodeJWT(id_token);
+            // Should have dynamic claim but not email (no email scope granted)
+            expect(payload).to.have.key('dynamic_claim');
+            // Email should be filtered by grant permissions
+            // Note: This test may need adjustment based on actual grant filtering behavior
+          });
+      });
+    });
+  });
+
+  describe('static claims still work with allowDynamicClaims enabled', () => {
+    before(function () {
+      return this.login({
+        claims: {
+          id_token: {
+            email: null,
+          },
+        },
+      });
+    });
+    after(function () { return this.logout(); });
+
+    it('should continue to work with static claims', function () {
+      const auth = new this.AuthorizationRequest({
+        response_type: 'id_token token',
+        scope: 'openid email',
+        claims: {
+          id_token: {
+            email: null, // Static claim should still work
+          },
+        },
+      });
+
+      return this.wrap({ route: '/auth', verb: 'get', auth })
+        .expect(303)
+        .expect(auth.validateFragment)
+        .expect(auth.validatePresence(['id_token'], false))
+        .expect((response) => {
+          const { query: { id_token } } = parseLocation(response.headers.location, true);
+          const { payload } = decodeJWT(id_token);
+          expect(payload).to.have.key('email');
+          expect(payload.email).to.equal('test@example.com');
+        });
+    });
+  });
+});
+
+// Test with external API simulation
+describe('allowDynamicClaims with external API integration', () => {
+  before(bootstrap(import.meta.url.replace('.test.js', '_api.config.js')));
+
+  it('should handle scope-based dynamic claims', function () {
+    return this.login()
+      .then(() => {
+        const auth = new this.AuthorizationRequest({
+          response_type: 'id_token token',
+          scope: 'openid profile custom',
+          claims: {
+            id_token: {
+              profile_from_api: null,
+              department: null,
+              custom_tenant_id: null,
+              permissions: null,
+            },
+          },
+        });
+
+        return this.wrap({ route: '/auth', verb: 'get', auth })
+          .expect(303)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['id_token'], false))
+          .expect((response) => {
+            const { query: { id_token } } = parseLocation(response.headers.location, true);
+            const { payload } = decodeJWT(id_token);
+            expect(payload).to.have.keys('profile_from_api', 'department', 'custom_tenant_id', 'permissions');
+            expect(payload.profile_from_api).to.equal('external_profile_data');
+            expect(payload.department).to.equal('engineering');
+            expect(payload.custom_tenant_id).to.equal('tenant_456');
+            expect(payload.permissions).to.deep.equal(['read', 'write']);
+          });
+      })
+      .then(() => this.logout());
+  });
+
+  it('should gracefully handle external API failures', function () {
+    // Override findAccount to simulate API failure
+    const originalFindAccount = this.provider.configuration.findAccount;
+    this.provider.configuration.findAccount = async function(ctx, sub) {
+      return {
+        accountId: sub,
+        async claims() {
+          // Simulate external API failure
+          try {
+            throw new Error('External API unavailable');
+          } catch (error) {
+            // Fallback to base claims
+            return {
+              sub,
+              email: 'test@example.com',
+            };
+          }
+        },
+      };
+    };
+
+    return this.login()
+      .then(() => {
+        const auth = new this.AuthorizationRequest({
+          response_type: 'id_token token',
+          scope: 'openid email',
+          claims: {
+            id_token: {
+              email: null,
+              external_claim: null, // This should be missing due to API failure
+            },
+          },
+        });
+
+        return this.wrap({ route: '/auth', verb: 'get', auth })
+          .expect(303)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['id_token'], false))
+          .expect((response) => {
+            const { query: { id_token } } = parseLocation(response.headers.location, true);
+            const { payload } = decodeJWT(id_token);
+            expect(payload).to.have.key('email'); // Base claim should be present
+            expect(payload).not.to.have.key('external_claim'); // Dynamic claim should be missing
+          });
+      })
+      .finally(() => {
+        // Restore original findAccount
+        this.provider.configuration.findAccount = originalFindAccount;
+      })
+      .then(() => this.logout());
+  });
+});

--- a/test/claims/allow_dynamic_claims_api.config.js
+++ b/test/claims/allow_dynamic_claims_api.config.js
@@ -1,0 +1,61 @@
+import merge from 'lodash/merge.js';
+
+import getConfig from '../default.config.js';
+
+const config = getConfig();
+
+// Enable claims parameter feature for testing
+merge(config.features, { claimsParameter: { enabled: true } });
+
+// Enable dynamic claims
+config.allowDynamicClaims = true;
+
+// Add some scopes for testing
+config.scopes = new Set(['openid', 'email', 'profile', 'custom']);
+
+// Define static claims that are always supported
+config.claims = {
+  openid: ['sub'],
+  email: ['email'],
+  profile: ['name', 'given_name', 'family_name'],
+  custom: [], // Empty but scope exists
+};
+
+// Override findAccount to simulate external API integration
+config.findAccount = async function(ctx, sub) {
+  return {
+    accountId: sub,
+    async claims(use, scope) {
+      const baseClaims = {
+        sub,
+        email: 'test@example.com',
+      };
+
+      // Simulate external API call based on scope
+      const externalClaims = {};
+      if (scope.includes('profile')) {
+        externalClaims.profile_from_api = 'external_profile_data';
+        externalClaims.department = 'engineering';
+      }
+      if (scope.includes('custom')) {
+        externalClaims.custom_tenant_id = 'tenant_456';
+        externalClaims.permissions = ['read', 'write'];
+      }
+
+      return { ...baseClaims, ...externalClaims };
+    },
+  };
+};
+
+export default {
+  config,
+  clients: [
+    {
+      client_id: 'client',
+      client_secret: 'secret',
+      grant_types: ['implicit', 'authorization_code'],
+      response_types: ['id_token token', 'id_token', 'code', 'none'],
+      redirect_uris: ['https://client.example.com/cb'],
+    },
+  ],
+};

--- a/test/claims/allow_dynamic_claims_enabled.config.js
+++ b/test/claims/allow_dynamic_claims_enabled.config.js
@@ -1,0 +1,53 @@
+import merge from 'lodash/merge.js';
+
+import getConfig from '../default.config.js';
+
+const config = getConfig();
+
+// Enable claims parameter feature for testing
+merge(config.features, { claimsParameter: { enabled: true } });
+
+// Enable dynamic claims
+config.allowDynamicClaims = true;
+
+// Add some scopes for testing
+config.scopes = new Set(['openid', 'email', 'profile', 'custom']);
+
+// Define static claims that are always supported
+config.claims = {
+  openid: ['sub'],
+  email: ['email'],
+  profile: ['name', 'given_name', 'family_name'],
+  custom: [], // Empty but scope exists
+};
+
+// Override findAccount to return dynamic claims
+config.findAccount = async function(ctx, sub) {
+  return {
+    accountId: sub,
+    async claims() {
+      return {
+        sub,
+        email: 'test@example.com',
+        name: 'Test User',
+        // Return dynamic claims that aren't in static configuration
+        dynamic_claim: 'dynamic_value',
+        external_api_claim: 'from_external_api',
+        tenant_specific_claim: 'tenant_123',
+      };
+    },
+  };
+};
+
+export default {
+  config,
+  clients: [
+    {
+      client_id: 'client',
+      client_secret: 'secret',
+      grant_types: ['implicit', 'authorization_code'],
+      response_types: ['id_token token', 'id_token', 'code', 'none'],
+      redirect_uris: ['https://client.example.com/cb'],
+    },
+  ],
+};

--- a/test/claims/dynamic_claims_basic.test.js
+++ b/test/claims/dynamic_claims_basic.test.js
@@ -1,0 +1,205 @@
+import { expect } from 'chai';
+
+import Provider from '../../lib/index.js';
+
+describe('allowDynamicClaims basic functionality', () => {
+  describe('when allowDynamicClaims is false (default)', () => {
+    it('should filter out dynamic claims from Claims helper', async () => {
+      const provider = new Provider('https://op.example.com', {
+        allowDynamicClaims: false, // Explicit false
+        claims: {
+          openid: ['sub'],
+          email: ['email'],
+        },
+      });
+
+      // Create a mock client
+      const client = {
+        clientId: 'test-client',
+        subjectType: 'public',
+      };
+
+      const { Claims } = provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        email: 'test@example.com',
+        dynamic_claim: 'should_be_filtered',
+        external_api_claim: 'also_filtered',
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      // Mask specific claims
+      claims.mask({
+        sub: null,
+        email: null,
+        dynamic_claim: null,
+        external_api_claim: null,
+      });
+      
+      const result = await claims.result();
+
+      // Should only include static claims
+      expect(result).to.have.keys('sub', 'email');
+      expect(result).not.to.have.keys('dynamic_claim', 'external_api_claim');
+      expect(result.sub).to.equal('user123');
+      expect(result.email).to.equal('test@example.com');
+    });
+  });
+
+  describe('when allowDynamicClaims is true', () => {
+    it('should include dynamic claims from Claims helper', async () => {
+      const provider = new Provider('https://op.example.com', {
+        allowDynamicClaims: true, // Enable dynamic claims
+        claims: {
+          openid: ['sub'],
+          email: ['email'],
+        },
+      });
+
+      // Create a mock client
+      const client = {
+        clientId: 'test-client',
+        subjectType: 'public',
+      };
+
+      const { Claims } = provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        email: 'test@example.com',
+        dynamic_claim: 'dynamic_value',
+        external_api_claim: 'from_api',
+        tenant_specific: 'tenant_data',
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      // Mask specific claims including dynamic ones
+      claims.mask({
+        sub: null,
+        email: null,
+        dynamic_claim: null,
+        external_api_claim: null,
+        tenant_specific: null,
+      });
+      
+      const result = await claims.result();
+
+      // Should include both static and dynamic claims
+      expect(result).to.have.keys('sub', 'email', 'dynamic_claim', 'external_api_claim', 'tenant_specific');
+      expect(result.sub).to.equal('user123');
+      expect(result.email).to.equal('test@example.com');
+      expect(result.dynamic_claim).to.equal('dynamic_value');
+      expect(result.external_api_claim).to.equal('from_api');
+      expect(result.tenant_specific).to.equal('tenant_data');
+    });
+  });
+
+  describe('OIDCContext claims parameter validation', () => {
+    it('should filter dynamic claims when allowDynamicClaims is false', () => {
+      const provider = new Provider('https://op.example.com', {
+        allowDynamicClaims: false,
+        claims: {
+          openid: ['sub'],
+          email: ['email'],
+        },
+      });
+
+      // Create a mock context with claims parameter
+      const mockCtx = {
+        oidc: {
+          params: {
+            claims: JSON.stringify({
+              id_token: {
+                email: null,
+                dynamic_claim: null, // Should be filtered
+                external_claim: null, // Should be filtered
+              },
+            }),
+          },
+        },
+      };
+
+      const oidcContext = new provider.OIDCContext(mockCtx);
+      const requestParamClaims = oidcContext.requestParamClaims;
+
+      // Should only include static claims
+      expect([...requestParamClaims]).to.include('email');
+      expect([...requestParamClaims]).not.to.include('dynamic_claim');
+      expect([...requestParamClaims]).not.to.include('external_claim');
+    });
+
+    it('should include dynamic claims when allowDynamicClaims is true', () => {
+      const provider = new Provider('https://op.example.com', {
+        allowDynamicClaims: true,
+        claims: {
+          openid: ['sub'],
+          email: ['email'],
+        },
+      });
+
+      // Create a mock context with claims parameter
+      const mockCtx = {
+        oidc: {
+          params: {
+            claims: JSON.stringify({
+              id_token: {
+                email: null,
+                dynamic_claim: null, // Should be included
+                external_claim: null, // Should be included
+              },
+            }),
+          },
+        },
+      };
+
+      const oidcContext = new provider.OIDCContext(mockCtx);
+      const requestParamClaims = oidcContext.requestParamClaims;
+
+      // Should include both static and dynamic claims
+      expect([...requestParamClaims]).to.include('email');
+      expect([...requestParamClaims]).to.include('dynamic_claim');
+      expect([...requestParamClaims]).to.include('external_claim');
+    });
+  });
+
+  describe('Configuration inheritance and defaults', () => {
+    it('should default to false when not specified', () => {
+      const provider = new Provider('https://op.example.com', {
+        claims: {
+          openid: ['sub'],
+        },
+      });
+
+      // Access the configuration via internal API
+      const config = provider.configuration || provider.issuer.configuration;
+      expect(config.allowDynamicClaims).to.equal(false);
+    });
+
+    it('should respect explicit true setting', () => {
+      const provider = new Provider('https://op.example.com', {
+        allowDynamicClaims: true,
+        claims: {
+          openid: ['sub'],
+        },
+      });
+
+      const config = provider.configuration || provider.issuer.configuration;
+      expect(config.allowDynamicClaims).to.equal(true);
+    });
+
+    it('should respect explicit false setting', () => {
+      const provider = new Provider('https://op.example.com', {
+        allowDynamicClaims: false,
+        claims: {
+          openid: ['sub'],
+        },
+      });
+
+      const config = provider.configuration || provider.issuer.configuration;
+      expect(config.allowDynamicClaims).to.equal(false);
+    });
+  });
+});

--- a/test/configuration/allow_dynamic_claims.test.js
+++ b/test/configuration/allow_dynamic_claims.test.js
@@ -1,0 +1,105 @@
+import { expect } from 'chai';
+
+import Configuration from '../../lib/helpers/configuration.js';
+import getDefaults from '../../lib/helpers/defaults.js';
+
+describe('allowDynamicClaims configuration', () => {
+  it('should have default value of false', () => {
+    const defaults = getDefaults();
+    expect(defaults.allowDynamicClaims).to.equal(false);
+  });
+
+  it('should accept boolean true', () => {
+    const config = new Configuration({
+      allowDynamicClaims: true,
+    });
+    expect(config.allowDynamicClaims).to.equal(true);
+  });
+
+  it('should accept boolean false', () => {
+    const config = new Configuration({
+      allowDynamicClaims: false,
+    });
+    expect(config.allowDynamicClaims).to.equal(false);
+  });
+
+  it('should use default when not specified', () => {
+    const config = new Configuration({});
+    expect(config.allowDynamicClaims).to.equal(false);
+  });
+
+  it('should accept non-boolean values (no validation)', () => {
+    // The configuration system doesn't validate basic property types
+    // This is consistent with other configuration properties
+    const config1 = new Configuration({
+      allowDynamicClaims: 'true',
+    });
+    expect(config1.allowDynamicClaims).to.equal('true');
+
+    const config2 = new Configuration({
+      allowDynamicClaims: 1,
+    });
+    expect(config2.allowDynamicClaims).to.equal(1);
+
+    const config3 = new Configuration({
+      allowDynamicClaims: null,
+    });
+    expect(config3.allowDynamicClaims).to.equal(null);
+  });
+
+  it('should work with other configuration options', () => {
+    const config = new Configuration({
+      allowDynamicClaims: true,
+      issuer: 'https://op.example.com',
+      features: {
+        claimsParameter: { enabled: true },
+        userinfo: { enabled: true },
+      },
+      claims: {
+        openid: ['sub'],
+        email: ['email'],
+      },
+    });
+
+    expect(config.allowDynamicClaims).to.equal(true);
+    expect(config.features.claimsParameter.enabled).to.equal(true);
+    expect(config.features.userinfo.enabled).to.equal(true);
+  });
+
+  it('should not affect claimsSupported when disabled', () => {
+    const config = new Configuration({
+      allowDynamicClaims: false,
+      claims: {
+        openid: ['sub'],
+        email: ['email'],
+        profile: ['name', 'family_name'],
+      },
+    });
+
+    expect(config.allowDynamicClaims).to.equal(false);
+    expect(config.claimsSupported.has('sub')).to.equal(true);
+    expect(config.claimsSupported.has('email')).to.equal(true);
+    expect(config.claimsSupported.has('name')).to.equal(true);
+    expect(config.claimsSupported.has('family_name')).to.equal(true);
+    expect(config.claimsSupported.has('non_existent')).to.equal(false);
+  });
+
+  it('should not affect claimsSupported when enabled', () => {
+    const config = new Configuration({
+      allowDynamicClaims: true,
+      claims: {
+        openid: ['sub'],
+        email: ['email'],
+        profile: ['name', 'family_name'],
+      },
+    });
+
+    expect(config.allowDynamicClaims).to.equal(true);
+    // claimsSupported should still be computed normally
+    expect(config.claimsSupported.has('sub')).to.equal(true);
+    expect(config.claimsSupported.has('email')).to.equal(true);
+    expect(config.claimsSupported.has('name')).to.equal(true);
+    expect(config.claimsSupported.has('family_name')).to.equal(true);
+    expect(config.claimsSupported.has('non_existent')).to.equal(false);
+  });
+});

--- a/test/helpers/claims_dynamic.config.js
+++ b/test/helpers/claims_dynamic.config.js
@@ -1,0 +1,23 @@
+import getConfig from '../default.config.js';
+
+const config = getConfig();
+
+// Define static claims
+config.claims = {
+  openid: ['sub'],
+  email: ['email'],
+  profile: ['name', 'family_name'],
+};
+
+export default {
+  config,
+  clients: [
+    {
+      client_id: 'client',
+      client_secret: 'secret',
+      grant_types: ['authorization_code', 'implicit'],
+      response_types: ['code', 'id_token', 'id_token token'],
+      redirect_uris: ['https://client.example.com/cb'],
+    },
+  ],
+};

--- a/test/helpers/claims_dynamic.test.js
+++ b/test/helpers/claims_dynamic.test.js
@@ -1,0 +1,247 @@
+import { expect } from 'chai';
+
+import bootstrap from '../test_helper.js';
+
+describe('Claims helper with allowDynamicClaims', () => {
+  describe('when allowDynamicClaims is false (default)', () => {
+    before(bootstrap(import.meta.url));
+
+    it('should filter out non-static claims', async function () {
+      const client = await this.provider.Client.find('client');
+      const { Claims } = this.provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        email: 'test@example.com',
+        name: 'Test User',
+        dynamic_claim: 'should_be_filtered',
+        external_api_claim: 'also_filtered',
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      // Apply scope filtering
+      claims.scope('openid email profile');
+      
+      const result = await claims.result();
+
+      expect(result).to.have.keys('sub', 'email', 'name');
+      expect(result).not.to.have.keys('dynamic_claim', 'external_api_claim');
+      expect(result.sub).to.equal('user123');
+      expect(result.email).to.equal('test@example.com');
+      expect(result.name).to.equal('Test User');
+    });
+
+    it('should filter claims when using mask directly', async function () {
+      const client = await this.provider.Client.find('client');
+      const { Claims } = this.provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        email: 'test@example.com',
+        dynamic_claim: 'should_be_filtered',
+        another_dynamic_claim: 'also_filtered',
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      // Apply specific claim mask
+      claims.mask({
+        sub: null,
+        email: null,
+        dynamic_claim: null,
+        another_dynamic_claim: null,
+      });
+      
+      const result = await claims.result();
+
+      expect(result).to.have.keys('sub', 'email');
+      expect(result).not.to.have.keys('dynamic_claim', 'another_dynamic_claim');
+    });
+  });
+
+  describe('when allowDynamicClaims is true', () => {
+    before(bootstrap(import.meta.url.replace('.test.js', '_enabled.config.js')));
+
+    it('should include dynamic claims', async function () {
+      const client = await this.provider.Client.find('client');
+      const { Claims } = this.provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        email: 'test@example.com',
+        name: 'Test User',
+        dynamic_claim: 'dynamic_value',
+        external_api_claim: 'from_api',
+        tenant_specific: 'tenant_data',
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      // Apply scope filtering
+      claims.scope('openid email profile');
+      
+      const result = await claims.result();
+
+      expect(result).to.have.keys('sub', 'email', 'name');
+      expect(result.sub).to.equal('user123');
+      expect(result.email).to.equal('test@example.com');
+      expect(result.name).to.equal('Test User');
+      
+      // Note: scope-based claims may not include dynamic claims unless explicitly requested
+      // Let's test with explicit mask
+    });
+
+    it('should include dynamic claims when explicitly masked', async function () {
+      const client = await this.provider.Client.find('client');
+      const { Claims } = this.provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        email: 'test@example.com',
+        dynamic_claim: 'dynamic_value',
+        external_api_claim: 'from_api',
+        tenant_specific: 'tenant_data',
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      // Apply specific claim mask including dynamic claims
+      claims.mask({
+        sub: null,
+        email: null,
+        dynamic_claim: null,
+        external_api_claim: null,
+        tenant_specific: null,
+      });
+      
+      const result = await claims.result();
+
+      expect(result).to.have.keys('sub', 'email', 'dynamic_claim', 'external_api_claim', 'tenant_specific');
+      expect(result.sub).to.equal('user123');
+      expect(result.email).to.equal('test@example.com');
+      expect(result.dynamic_claim).to.equal('dynamic_value');
+      expect(result.external_api_claim).to.equal('from_api');
+      expect(result.tenant_specific).to.equal('tenant_data');
+    });
+
+    it('should handle mixed static and dynamic claims', async function () {
+      const client = await this.provider.Client.find('client');
+      const { Claims } = this.provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        email: 'test@example.com',
+        name: 'Test User',
+        custom_attr_1: 'value1',
+        custom_attr_2: 'value2',
+        api_generated_claim: { complex: 'object' },
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      claims.mask({
+        sub: null,
+        email: null,
+        name: null,
+        custom_attr_1: null,
+        custom_attr_2: null,
+        api_generated_claim: null,
+      });
+      
+      const result = await claims.result();
+
+      expect(result).to.have.keys('sub', 'email', 'name', 'custom_attr_1', 'custom_attr_2', 'api_generated_claim');
+      expect(result.sub).to.equal('user123');
+      expect(result.email).to.equal('test@example.com');
+      expect(result.name).to.equal('Test User');
+      expect(result.custom_attr_1).to.equal('value1');
+      expect(result.custom_attr_2).to.equal('value2');
+      expect(result.api_generated_claim).to.deep.equal({ complex: 'object' });
+    });
+
+    it('should still work with static claims only', async function () {
+      const client = await this.provider.Client.find('client');
+      const { Claims } = this.provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        email: 'test@example.com',
+        name: 'Test User',
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      claims.scope('openid email profile');
+      
+      const result = await claims.result();
+
+      expect(result).to.have.keys('sub', 'email', 'name');
+      expect(result.sub).to.equal('user123');
+      expect(result.email).to.equal('test@example.com');
+      expect(result.name).to.equal('Test User');
+    });
+
+    it('should handle edge cases with null and undefined values', async function () {
+      const client = await this.provider.Client.find('client');
+      const { Claims } = this.provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        nullable_claim: null,
+        undefined_claim: undefined,
+        empty_string_claim: '',
+        zero_claim: 0,
+        false_claim: false,
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      claims.mask({
+        sub: null,
+        nullable_claim: null,
+        undefined_claim: null,
+        empty_string_claim: null,
+        zero_claim: null,
+        false_claim: null,
+      });
+      
+      const result = await claims.result();
+
+      expect(result).to.have.property('sub', 'user123');
+      expect(result).to.have.property('nullable_claim', null);
+      expect(result).to.have.property('empty_string_claim', '');
+      expect(result).to.have.property('zero_claim', 0);
+      expect(result).to.have.property('false_claim', false);
+      // undefined values are typically not included in JSON
+    });
+  });
+
+  describe('configuration edge cases', () => {
+    it('should handle provider without explicit allowDynamicClaims config', async function () {
+      // Use the existing provider which has default configuration
+      const client = await this.provider.Client.find('client');
+      const { Claims } = this.provider;
+
+      const availableClaims = {
+        sub: 'user123',
+        email: 'test@example.com',
+        dynamic_claim: 'should_be_filtered',
+      };
+
+      const claims = new Claims(availableClaims, { client });
+      
+      claims.mask({
+        sub: null,
+        email: null,
+        dynamic_claim: null,
+      });
+      
+      const result = await claims.result();
+
+      // Should behave like allowDynamicClaims: false (default)
+      expect(result).to.have.keys('sub', 'email');
+      expect(result).not.to.have.key('dynamic_claim');
+    });
+  });
+});

--- a/test/helpers/claims_dynamic_enabled.config.js
+++ b/test/helpers/claims_dynamic_enabled.config.js
@@ -1,0 +1,26 @@
+import getConfig from '../default.config.js';
+
+const config = getConfig();
+
+// Enable dynamic claims
+config.allowDynamicClaims = true;
+
+// Define static claims
+config.claims = {
+  openid: ['sub'],
+  email: ['email'],
+  profile: ['name', 'family_name'],
+};
+
+export default {
+  config,
+  clients: [
+    {
+      client_id: 'client',
+      client_secret: 'secret',
+      grant_types: ['authorization_code', 'implicit'],
+      response_types: ['code', 'id_token', 'id_token token'],
+      redirect_uris: ['https://client.example.com/cb'],
+    },
+  ],
+};


### PR DESCRIPTION
Add a new `allowDynamicClaims` config flag. If true, oidc-provider will pass through arbitrary claims returned from the findAccount.claims function, no longer constrained by the static scope-claim mappings passed into config on startup.