### PR TITLE
Allow cookies to be cleared for additional configured paths

### DIFF
--- a/lib/helpers/cookie_helpers.js
+++ b/lib/helpers/cookie_helpers.js
@@ -13,7 +13,18 @@ export async function shouldWriteCookies(ctx) {
 }
 
 export function clearAllCookies(ctx) {
+    const cookieConfig = instance(ctx.oidc.provider).configuration.cookies;
+    const clearCookiesAtAdditionalPaths = cookieConfig.clearCookiesAtAdditionalPaths || [];
+
+    // First clear the cookies at the 'main' path.
     ctx.cookies.set(ctx.oidc.provider.cookieName("interaction"), null);
     ctx.cookies.set(ctx.oidc.provider.cookieName("resume"), null);
     ctx.cookies.set(ctx.oidc.provider.cookieName("session"), null);
+
+    // Also clear cookies at any additional paths specified in the configuration.
+    for (const path of clearCookiesAtAdditionalPaths) {
+        ctx.cookies.set(ctx.oidc.provider.cookieName("interaction"), null, { path });
+        ctx.cookies.set(ctx.oidc.provider.cookieName("resume"), null, { path });
+        ctx.cookies.set(ctx.oidc.provider.cookieName("session"), null, { path });
+    }
 };

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -918,6 +918,22 @@ function makeDefaults() {
        * ```
        */
       shouldWriteCookies: undefined,
+
+      /*
+       * cookies.clearCookiesAtAdditionalPaths
+       *
+       * description: Array of additional paths where cookies should be cleared when the auth server
+       *   clears cookies. This is useful when cookies may have been set at different paths (e.g.,
+       *   by login applications) and need to be explicitly cleared to prevent interference with
+       *   subsequent authentication attempts.
+       *
+       * example: Clear cookies at both default path and login application path
+       *
+       * ```js
+       * clearCookiesAtAdditionalPaths: ['/login', '/auth']
+       * ```
+       */
+      clearCookiesAtAdditionalPaths: [],
     },
 
     /*


### PR DESCRIPTION
Add a new `clearCookiesAtAdditionalPaths` field to config, telling the auth server to clear cookies for additional paths, such as /login, if so configured. This is to clear up stale cookies that may have been set for the Civic login app in the past.